### PR TITLE
fix: fix gradlew migrate error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ jacksonVersion=2.13.3
 picocliVersion=4.6.3
 persistenceVersion=2.2.3
 cucumberVersion=7.8.1
+flywayMysqlVersion=8.2.2

--- a/todo-api/build.gradle
+++ b/todo-api/build.gradle
@@ -3,6 +3,7 @@ import org.flywaydb.gradle.task.*
 buildscript {
     dependencies {
         classpath "mysql:mysql-connector-java:$mysqlVersion"
+        classpath "org.flywaydb:flyway-mysql:$flywayMysqlVersion"
     }
 }
 


### PR DESCRIPTION
without flyway-mysql when execute ./gradlew migrate will throw error below:

```
> Task :todo-api:migrateToDev FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':todo-api:migrateToDev'.
> Error occurred while executing migrateToDev
  No database found to handle jdbc:mysql://localhost:3306/todo_dev?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true
```